### PR TITLE
Respect timeout specified by showDelay option even when using templateUrl

### DIFF
--- a/tipped.js
+++ b/tipped.js
@@ -121,7 +121,15 @@ tipped.directive('tipped',
             if (options.showOn) {
               element.bind(options.showOn, function () {
                 make().then(function (tt) {
-                  tt.show();
+                  if (options.showDelay) {
+                    // show after the specified delay
+                    $timeout(function() {
+                      tt.show();
+                    }, options.showDelay);
+                  } else {
+                    // show immediately
+                    tt.show();
+                  }
                 });
               });
               scope.$on('$destroy', function () {


### PR DESCRIPTION
Using the `showDelay` option didn't work when using `templateUrl`, the tooltip would always appear immediately -- this fixes that.